### PR TITLE
Fix - Invalid argument supplied to oneOfType, expected an instance of array

### DIFF
--- a/src/SelectMultiple.js
+++ b/src/SelectMultiple.js
@@ -4,10 +4,10 @@ import styles from './SelectMultiple.styles'
 import checkbox from '../images/icon-checkbox.png'
 import checkboxChecked from '../images/icon-checkbox-checked.png'
 
-const itemType = PropTypes.oneOfType(
+const itemType = PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.shape({ label: PropTypes.string, value: PropTypes.any })
-)
+])
 
 const styleType = PropTypes.oneOfType([
   PropTypes.object,


### PR DESCRIPTION
Just adding square brackets to fix this issue https://github.com/tableflip/react-native-select-multiple/issues/2

"Invalid argument supplied to oneOfType, expected an instance of array"

Thanks!